### PR TITLE
Work in progress: Fix cannot fill in fields with pipes (|) in name-attribute

### DIFF
--- a/src/Selector/Xpath/Manipulator.php
+++ b/src/Selector/Xpath/Manipulator.php
@@ -21,7 +21,7 @@ class Manipulator
     /**
      * Regex to find union operators not inside brackets.
      */
-    const UNION_PATTERN = '/\|(?![^\[]*\])/';
+    const UNION_PATTERN = '/\s\|\s(?![^\[]*\])/';
 
     /**
      * Prepends the XPath prefix to the given XPath.


### PR DESCRIPTION
Fixes non working sentence:

``` gherkin
Feature: fill in fields with pipes (|) in name-attribute

  Scenario:
    Given I am on "/test.html"
    When I fill in "a|b|c" with "foobar" #  the name selector could not be found
    Then the "a|b|c" field should contain "foobar"
```

Non working context

``` html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Title</title>
</head>
<body>
<form>
    <input type="text" name="a|b|c" />
</form>

</body>
</html>
```
